### PR TITLE
Change the desired sample size for crash points history samples

### DIFF
--- a/lib/crash-points-history-sample-collection.js
+++ b/lib/crash-points-history-sample-collection.js
@@ -83,7 +83,7 @@ async function collectCrashPointsHistorySampleData() {
         const recentCrashPointsHtmlElementObserver = new MutationObserver(
           () => {
             try {
-              const desiredCrashPointsHistorySampleSize = 16;
+              const desiredCrashPointsHistorySampleSize = 1000;
               const crashPointsHistorySampleDataPartial =
                 extractRecentCrashPointsFromGamePage();
               const numberOfCrashPointsCollectedSoFar =


### PR DESCRIPTION
Previous value was 16, now it's 1000.

The change was made for testing the collection of a big sample and for having it ready in order to aid in the development of the simulation aspect of the program.